### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library makes creating MQTT sketches easier on the ESP8266 as it 
 category=Communication
 url=https://github.com/surik00/ESPHelper
 architectures=esp8266
-includes=ESPHelper
+includes=ESPHelper.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via `Sketch > Include Library > ESPHelper`. The previous value of this field caused that action to add the following line to the sketch:
```
#include <ESPHelper>
```
but the correct filename is ESPHelper.h, not ESPHelper so that would cause a compilation error:
```
fatal error: ESPHelper: No such file or directory
```